### PR TITLE
Feat/remove init

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -18,7 +18,7 @@ contract Deploy is Script {
 
         address sender = vm.addr(pk);
         console2.log("Deploying RMM from", sender);
-        RMM rmm = FACTORY.createRMM("RMM", "RMM");
+        // RMM rmm = FACTORY.createRMM("RMM", "RMM");
 
         vm.stopBroadcast();
     }

--- a/script/DeployPool.s.sol
+++ b/script/DeployPool.s.sol
@@ -87,7 +87,7 @@ contract DeployPool is Script {
         uint256 pk = vm.envUint(ENV_PRIVATE_KEY);
         vm.startBroadcast(pk);
         sender = vm.addr(pk);
-        rmm = FACTORY.createRMM("Lido Staked ETH 24 Dec 2025", "stETH-24DEC25");
+        rmm = FACTORY.createRMM("Lido Staked ETH 24 Dec 2025", "stETH-24DEC25", address(PT), 0.02 ether, fee);
         console2.log("rmm address: ", address(rmm));
 
         mintSY(10_000 ether);
@@ -107,15 +107,7 @@ contract DeployPool is Script {
         PYIndex index = YT.newIndex();
         (MarketState memory ms, MarketPreCompute memory mp) = getPendleMarketData(index);
         uint256 price = uint256(getPtExchangeRate(index));
-        rmm.init({
-            PT_: address(PT),
-            priceX: price,
-            amountX: uint256(ms.totalSy),
-            strike_: uint256(mp.rateAnchor),
-            sigma_: 0.02 ether,
-            fee_: fee,
-            curator_: address(0x55)
-        });
+        rmm.init({priceX: price, amountX: uint256(ms.totalSy), strike_: uint256(mp.rateAnchor)});
 
         vm.stopBroadcast();
     }

--- a/src/Factory.sol
+++ b/src/Factory.sol
@@ -1,9 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.13;
 
+import {PYIndexLib, PYIndex} from "pendle/core/StandardizedYield/PYIndex.sol";
+import {IPYieldToken} from "pendle/interfaces/IPYieldToken.sol";
+import {IPPrincipalToken} from "pendle/interfaces/IPPrincipalToken.sol";
+import {computeTauWadYears, PoolPreCompute, computeLGivenX, computeY, solveL} from "./lib/RmmLib.sol";
 import {RMM} from "./RMM.sol";
 
 contract Factory {
+    using PYIndexLib for IPYieldToken;
+    using PYIndexLib for PYIndex;
+
     event NewPool(address indexed caller, address indexed pool, string name, string symbol);
 
     address public immutable WETH;
@@ -14,10 +21,39 @@ contract Factory {
         WETH = weth_;
     }
 
-    function createRMM(string memory poolName, string memory poolSymbol) external returns (RMM) {
-        RMM rmm = new RMM(WETH, poolName, poolSymbol);
+    function createRMM(
+        string memory poolName,
+        string memory poolSymbol,
+        address PT_,
+        uint256 priceX,
+        uint256 amountX,
+        uint256 strike_,
+        uint256 sigma_,
+        uint256 fee_,
+        address curator_
+    ) external returns (RMM) {
+        RMM rmm = new RMM(WETH, poolName, poolSymbol, PT_, priceX, amountX, strike_, sigma_, fee_, curator_);
         emit NewPool(msg.sender, address(rmm), poolName, poolSymbol);
         pools.push(address(rmm));
         return rmm;
+    }
+
+    function prepareInit(
+        address PT,
+        uint256 priceX,
+        uint256 amountX,
+        uint256 strike_,
+        uint256 sigma_,
+        uint256 maturity_
+    ) public returns (uint256 totalLiquidity_, uint256 amountY) {
+        PYIndex index = IPYieldToken(IPPrincipalToken(PT).YT()).newIndex();
+        uint256 totalAsset = index.syToAsset(amountX);
+        uint256 tau_ = computeTauWadYears(maturity_ - block.timestamp);
+        PoolPreCompute memory comp = PoolPreCompute({reserveInAsset: totalAsset, strike_: strike_, tau_: tau_});
+        uint256 initialLiquidity =
+            computeLGivenX({reserveX_: totalAsset, S: priceX, strike_: strike_, sigma_: sigma_, tau_: tau_});
+        amountY =
+            computeY({reserveX_: totalAsset, liquidity: initialLiquidity, strike_: strike_, sigma_: sigma_, tau_: tau_});
+        totalLiquidity_ = solveL(comp, initialLiquidity, amountY, sigma_);
     }
 }

--- a/src/Factory.sol
+++ b/src/Factory.sol
@@ -1,15 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.13;
 
-import {PYIndexLib, PYIndex} from "pendle/core/StandardizedYield/PYIndex.sol";
-import {IPYieldToken} from "pendle/interfaces/IPYieldToken.sol";
-import {computeTauWadYears, PoolPreCompute, computeLGivenX, computeY, solveL} from "./lib/RmmLib.sol";
 import {RMM} from "./RMM.sol";
 
 contract Factory {
-    using PYIndexLib for IPYieldToken;
-    using PYIndexLib for PYIndex;
-
     event NewPool(address indexed caller, address indexed pool, string name, string symbol);
 
     address public immutable WETH;
@@ -20,38 +14,13 @@ contract Factory {
         WETH = weth_;
     }
 
-    function createRMM(
-        string memory poolName,
-        string memory poolSymbol,
-        address PT_,
-        uint256 priceX,
-        uint256 amountX,
-        uint256 strike_,
-        uint256 sigma_,
-        uint256 fee_,
-        address curator_
-    ) external returns (RMM) {
-        RMM rmm = new RMM(WETH, poolName, poolSymbol, PT_, priceX, amountX, strike_, sigma_, fee_, curator_);
+    function createRMM(string memory poolName, string memory poolSymbol, address PT, uint256 sigma, uint256 fee)
+        external
+        returns (RMM)
+    {
+        RMM rmm = new RMM(poolName, poolSymbol, PT, sigma, fee);
         emit NewPool(msg.sender, address(rmm), poolName, poolSymbol);
         pools.push(address(rmm));
         return rmm;
-    }
-
-    function prepareInit(
-        uint256 priceX,
-        uint256 amountX,
-        uint256 strike_,
-        uint256 sigma_,
-        uint256 maturity_,
-        PYIndex index
-    ) public view returns (uint256 totalLiquidity_, uint256 amountY) {
-        uint256 totalAsset = index.syToAsset(amountX);
-        uint256 tau_ = computeTauWadYears(maturity_ - block.timestamp);
-        PoolPreCompute memory comp = PoolPreCompute({reserveInAsset: totalAsset, strike_: strike_, tau_: tau_});
-        uint256 initialLiquidity =
-            computeLGivenX({reserveX_: totalAsset, S: priceX, strike_: strike_, sigma_: sigma_, tau_: tau_});
-        amountY =
-            computeY({reserveX_: totalAsset, liquidity: initialLiquidity, strike_: strike_, sigma_: sigma_, tau_: tau_});
-        totalLiquidity_ = solveL(comp, initialLiquidity, amountY, sigma_);
     }
 }

--- a/src/Factory.sol
+++ b/src/Factory.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.13;
 
 import {PYIndexLib, PYIndex} from "pendle/core/StandardizedYield/PYIndex.sol";
 import {IPYieldToken} from "pendle/interfaces/IPYieldToken.sol";
-import {IPPrincipalToken} from "pendle/interfaces/IPPrincipalToken.sol";
 import {computeTauWadYears, PoolPreCompute, computeLGivenX, computeY, solveL} from "./lib/RmmLib.sol";
 import {RMM} from "./RMM.sol";
 
@@ -39,14 +38,13 @@ contract Factory {
     }
 
     function prepareInit(
-        address PT,
         uint256 priceX,
         uint256 amountX,
         uint256 strike_,
         uint256 sigma_,
-        uint256 maturity_
-    ) public returns (uint256 totalLiquidity_, uint256 amountY) {
-        PYIndex index = IPYieldToken(IPPrincipalToken(PT).YT()).newIndex();
+        uint256 maturity_,
+        PYIndex index
+    ) public view returns (uint256 totalLiquidity_, uint256 amountY) {
         uint256 totalAsset = index.syToAsset(amountX);
         uint256 tau_ = computeTauWadYears(maturity_ - block.timestamp);
         PoolPreCompute memory comp = PoolPreCompute({reserveInAsset: totalAsset, strike_: strike_, tau_: tau_});

--- a/src/RMM.sol
+++ b/src/RMM.sol
@@ -66,14 +66,10 @@ contract RMM is ERC20 {
         }
     }
 
-    constructor(address weth_, string memory name_, string memory symbol_) ERC20(name_, symbol_, 18) {
-        WETH = weth_;
-    }
-
-    receive() external payable {}
-
-    /// @dev Initializes the pool with an initial price, amount of `x` tokens, and parameters.
-    function init(
+    constructor(
+        address weth_,
+        string memory name_,
+        string memory symbol_,
         address PT_,
         uint256 priceX,
         uint256 amountX,
@@ -81,8 +77,24 @@ contract RMM is ERC20 {
         uint256 sigma_,
         uint256 fee_,
         address curator_
-    ) external lock {
-        if (strike != 0) revert AlreadyInitialized();
+    ) ERC20(name_, symbol_, 18) {
+        WETH = weth_;
+
+        _init(PT_, priceX, amountX, strike_, sigma_, fee_, curator_);
+    }
+
+    receive() external payable {}
+
+    /// @dev Initializes the pool with an initial price, amount of `x` tokens, and parameters.
+    function _init(
+        address PT_,
+        uint256 priceX,
+        uint256 amountX,
+        uint256 strike_,
+        uint256 sigma_,
+        uint256 fee_,
+        address curator_
+    ) internal {
         if (strike_ <= 1e18) revert InvalidStrike();
         PT = IPPrincipalToken(PT_);
         SY = IStandardizedYield(PT.SY());

--- a/src/lib/RmmEvents.sol
+++ b/src/lib/RmmEvents.sol
@@ -12,8 +12,7 @@ event Init(
     uint256 strike,
     uint256 sigma,
     uint256 fee,
-    uint256 maturity,
-    address indexed curator
+    uint256 maturity
 );
 
 /// @dev Emitted on swaps.

--- a/test/MockRMM.sol
+++ b/test/MockRMM.sol
@@ -5,18 +5,9 @@ import "./../src/RMM.sol";
 
 /// @dev Extends the RMM contract to expose internal functions for testing.
 contract MockRMM is RMM {
-    constructor(
-        address weth_,
-        string memory name_,
-        string memory symbol_,
-        address PT_,
-        uint256 priceX,
-        uint256 amountX,
-        uint256 strike_,
-        uint256 sigma_,
-        uint256 fee_,
-        address curator_
-    ) RMM(weth_, name_, symbol_, PT_, priceX, amountX, strike_, sigma_, fee_, curator_) {}
+    constructor(string memory name_, string memory symbol_, address PT_, uint256 sigma_, uint256 fee_)
+        RMM(name_, symbol_, PT_, sigma_, fee_)
+    {}
 
     function debit(address token, uint256 amountWad) public returns (uint256 paymentNative) {
         return _debit(token, amountWad);

--- a/test/MockRMM.sol
+++ b/test/MockRMM.sol
@@ -5,9 +5,18 @@ import "./../src/RMM.sol";
 
 /// @dev Extends the RMM contract to expose internal functions for testing.
 contract MockRMM is RMM {
-    constructor(address weth_, string memory name_, string memory symbol_) RMM(weth_, name_, symbol_) {
-        WETH = weth_;
-    }
+    constructor(
+        address weth_,
+        string memory name_,
+        string memory symbol_,
+        address PT_,
+        uint256 priceX,
+        uint256 amountX,
+        uint256 strike_,
+        uint256 sigma_,
+        uint256 fee_,
+        address curator_
+    ) RMM(weth_, name_, symbol_, PT_, priceX, amountX, strike_, sigma_, fee_, curator_) {}
 
     function debit(address token, uint256 amountWad) public returns (uint256 paymentNative) {
         return _debit(token, amountWad);

--- a/test/SetUp.sol
+++ b/test/SetUp.sol
@@ -27,6 +27,12 @@ struct InitParams {
     address curator;
 }
 
+uint32 constant DEFAULT_NOW = 1719578346;
+uint32 constant DEFAULT_EXPIRY = DEFAULT_NOW + 365 days;
+
+string constant DEFAULT_NAME = "RMM-LP-TOKEN";
+string constant DEFAULT_SYMBOL = "RMM-LPT";
+
 // address constant wstETH = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0; //real wsteth
 // address constant WETH_ADDRESS = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
@@ -42,11 +48,6 @@ contract SetUp is Test {
     IPPrincipalToken public PT;
     MockWstETH public wstETH;
     MockStETH public stETH;
-
-    // Some default constants.
-
-    uint32 public constant DEFAULT_NOW = 1719578346;
-    uint32 public constant DEFAULT_EXPIRY = DEFAULT_NOW + 365 days;
 
     // Main setup functions.
 
@@ -83,8 +84,8 @@ contract SetUp is Test {
     function setUpRMM(InitParams memory initParams) public {
         rmm = new MockRMM(
             address(weth),
-            "RMM-LP-TOKEN",
-            "RMM-LPT",
+            DEFAULT_NAME,
+            DEFAULT_SYMBOL,
             initParams.PT,
             initParams.priceX,
             initParams.amountX,

--- a/test/WstETH.sol
+++ b/test/WstETH.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+import {ERC20} from "solmate/tokens/ERC20.sol";
+
+interface IStETH {
+    function getPooledEthByShares(uint256 _sharesAmount) external view returns (uint256);
+
+    function getSharesByPooledEth(uint256 _pooledEthAmount) external view returns (uint256);
+
+    function submit(address _referral) external payable returns (uint256);
+}
+
+contract WstETH is ERC20 {
+    IStETH public stETH;
+
+    /**
+     * @param _stETH address of the StETH token to wrap
+     */
+    constructor(address _stETH) ERC20("Wrapped liquid staked Ether 2.0", "wstETH", 18) {
+        stETH = IStETH(_stETH);
+    }
+
+    /**
+     * @notice Exchanges stETH to wstETH
+     * @param _stETHAmount amount of stETH to wrap in exchange for wstETH
+     * @dev Requirements:
+     *  - `_stETHAmount` must be non-zero
+     *  - msg.sender must approve at least `_stETHAmount` stETH to this
+     *    contract.
+     *  - msg.sender must have at least `_stETHAmount` of stETH.
+     * User should first approve _stETHAmount to the WstETH contract
+     * @return Amount of wstETH user receives after wrap
+     */
+    function wrap(uint256 _stETHAmount) external returns (uint256) {
+        require(_stETHAmount > 0, "wstETH: can't wrap zero stETH");
+        uint256 wstETHAmount = stETH.getSharesByPooledEth(_stETHAmount);
+        _mint(msg.sender, wstETHAmount);
+        ERC20(address(stETH)).transferFrom(msg.sender, address(this), _stETHAmount);
+        return wstETHAmount;
+    }
+
+    /**
+     * @notice Exchanges wstETH to stETH
+     * @param _wstETHAmount amount of wstETH to uwrap in exchange for stETH
+     * @dev Requirements:
+     *  - `_wstETHAmount` must be non-zero
+     *  - msg.sender must have at least `_wstETHAmount` wstETH.
+     * @return Amount of stETH user receives after unwrap
+     */
+    function unwrap(uint256 _wstETHAmount) external returns (uint256) {
+        require(_wstETHAmount > 0, "wstETH: zero amount unwrap not allowed");
+        uint256 stETHAmount = stETH.getPooledEthByShares(_wstETHAmount);
+        _burn(msg.sender, _wstETHAmount);
+        ERC20(address(stETH)).transfer(msg.sender, stETHAmount);
+        return stETHAmount;
+    }
+
+    /**
+     * @notice Shortcut to stake ETH and auto-wrap returned stETH
+     */
+    receive() external payable {
+        uint256 shares = stETH.submit{value: msg.value}(address(0));
+        _mint(msg.sender, shares);
+    }
+
+    /**
+     * @notice Get amount of wstETH for a given amount of stETH
+     * @param _stETHAmount amount of stETH
+     * @return Amount of wstETH for a given stETH amount
+     */
+    function getWstETHByStETH(uint256 _stETHAmount) external view returns (uint256) {
+        return stETH.getSharesByPooledEth(_stETHAmount);
+    }
+
+    /**
+     * @notice Get amount of stETH for a given amount of wstETH
+     * @param _wstETHAmount amount of wstETH
+     * @return Amount of stETH for a given wstETH amount
+     */
+    function getStETHByWstETH(uint256 _wstETHAmount) external view returns (uint256) {
+        return stETH.getPooledEthByShares(_wstETHAmount);
+    }
+
+    /**
+     * @notice Get amount of stETH for a one wstETH
+     * @return Amount of stETH for 1 wstETH
+     */
+    function stEthPerToken() external view returns (uint256) {
+        return stETH.getPooledEthByShares(1 ether);
+    }
+
+    /**
+     * @notice Get amount of wstETH for a one stETH
+     * @return Amount of wstETH for a 1 stETH
+     */
+    function tokensPerStEth() external view returns (uint256) {
+        return stETH.getSharesByPooledEth(1 ether);
+    }
+}

--- a/test/invariant/RMMHandler.sol
+++ b/test/invariant/RMMHandler.sol
@@ -93,13 +93,13 @@ contract RMMHandler is CommonBase, StdUtils, StdCheats {
 
         PYIndex index = IPYieldToken(PT.YT()).newIndex();
 
-        (uint256 totalLiquidity, uint256 amountY) = rmm.prepareInit(priceX, amountX, strike, sigma, PT.expiry(), index);
+        (uint256 totalLiquidity, uint256 amountY) = rmm.prepareInit(priceX, amountX, strike, sigma, index);
 
         PT.approve(address(rmm), type(uint256).max);
         SY.approve(address(rmm), type(uint256).max);
         YT.approve(address(rmm), type(uint256).max);
 
-        rmm.init(address(PT), priceX, amountX, strike, sigma, fee, address(0));
+        rmm.init(priceX, amountX, strike);
 
         ghost_reserveX += amountX;
         ghost_reserveY += amountY;

--- a/test/invariant/RMMInvariants.t.sol
+++ b/test/invariant/RMMInvariants.t.sol
@@ -2,20 +2,18 @@
 pragma solidity ^0.8.13;
 
 import {console} from "forge-std/console.sol";
-import {PYIndex, PYIndexLib} from "pendle/core/StandardizedYield/PYIndex.sol";
 import {abs} from "./../../src/lib/RmmLib.sol";
-import {IPYieldToken} from "pendle/interfaces/IPYieldToken.sol";
 import {SetUp} from "../SetUp.sol";
 import {RMMHandler} from "./RMMHandler.sol";
-import "forge-std/console2.sol";
 
 contract RMMInvariantsTest is SetUp {
-    using PYIndexLib for IPYieldToken;
-
     RMMHandler handler;
 
     function setUp() public virtual override {
         super.setUp();
+
+        // This will redeploy the RMM contract without initializing the pool
+        setUpRMM(getDefaultParams());
         handler = new RMMHandler(rmm, PT, SY, YT, weth);
 
         mintSY(address(handler), 1000 ether);

--- a/test/unit/Constructor.t.sol
+++ b/test/unit/Constructor.t.sol
@@ -1,7 +1,7 @@
 /// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {SetUp, RMM, InitParams, DEFAULT_NAME, DEFAULT_SYMBOL} from "../SetUp.sol";
+import {SetUp, RMM, InitParams, DEFAULT_NAME, DEFAULT_SYMBOL, DEFAULT_EXPIRY} from "../SetUp.sol";
 
 contract ConstructorTest is SetUp {
     function test_constructor_InitializesParameters() public useDefaultPool {
@@ -15,5 +15,11 @@ contract ConstructorTest is SetUp {
         assertEq(address(rmm.YT()), address(YT));
         assertEq(rmm.strike(), initParams.strike);
         assertEq(rmm.reserveX(), initParams.amountX);
+        assertEq(rmm.sigma(), initParams.sigma);
+        assertEq(rmm.fee(), initParams.fee);
+        assertEq(rmm.maturity(), DEFAULT_EXPIRY);
+        assertEq(rmm.curator(), initParams.curator);
+        assertEq(rmm.lastTimestamp(), block.timestamp);
+        assertEq(rmm.initTimestamp(), block.timestamp);
     }
 }

--- a/test/unit/Constructor.t.sol
+++ b/test/unit/Constructor.t.sol
@@ -4,22 +4,16 @@ pragma solidity ^0.8.13;
 import {SetUp, RMM, InitParams, DEFAULT_NAME, DEFAULT_SYMBOL, DEFAULT_EXPIRY} from "../SetUp.sol";
 
 contract ConstructorTest is SetUp {
-    function test_constructor_InitializesParameters() public useDefaultPool {
+    function test_constructor_InitializesParameters() public view {
         InitParams memory initParams = getDefaultParams();
 
-        assertEq(rmm.WETH(), address(weth));
         assertEq(rmm.name(), DEFAULT_NAME);
         assertEq(rmm.symbol(), DEFAULT_SYMBOL);
         assertEq(address(rmm.PT()), address(PT));
         assertEq(address(rmm.SY()), address(SY));
         assertEq(address(rmm.YT()), address(YT));
-        assertEq(rmm.strike(), initParams.strike);
-        assertEq(rmm.reserveX(), initParams.amountX);
         assertEq(rmm.sigma(), initParams.sigma);
         assertEq(rmm.fee(), initParams.fee);
         assertEq(rmm.maturity(), DEFAULT_EXPIRY);
-        assertEq(rmm.curator(), initParams.curator);
-        assertEq(rmm.lastTimestamp(), block.timestamp);
-        assertEq(rmm.initTimestamp(), block.timestamp);
     }
 }

--- a/test/unit/Constructor.t.sol
+++ b/test/unit/Constructor.t.sol
@@ -1,18 +1,19 @@
 /// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {Test, RMM} from "../SetUp.sol";
+import {SetUp, RMM, InitParams, DEFAULT_NAME, DEFAULT_SYMBOL} from "../SetUp.sol";
 
-contract ConstructorTest is Test {
-    function test_constructor_InitializesParameters() public {
-        address weth = address(0xbeef);
-        string memory name = "RMM-LP-TOKEN";
-        string memory symbol = "RMM-LPT";
+contract ConstructorTest is SetUp {
+    function test_constructor_InitializesParameters() public useDefaultPool {
+        InitParams memory initParams = getDefaultParams();
 
-        RMM rmm = new RMM(weth, name, symbol);
-
-        assertEq(rmm.WETH(), weth);
-        assertEq(rmm.name(), name);
-        assertEq(rmm.symbol(), symbol);
+        assertEq(rmm.WETH(), address(weth));
+        assertEq(rmm.name(), DEFAULT_NAME);
+        assertEq(rmm.symbol(), DEFAULT_SYMBOL);
+        assertEq(address(rmm.PT()), address(PT));
+        assertEq(address(rmm.SY()), address(SY));
+        assertEq(address(rmm.YT()), address(YT));
+        assertEq(rmm.strike(), initParams.strike);
+        assertEq(rmm.reserveX(), initParams.amountX);
     }
 }

--- a/test/unit/Credit.t.sol
+++ b/test/unit/Credit.t.sol
@@ -1,7 +1,18 @@
 /// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {Test} from "forge-std/Test.sol";
-import {MockRMM} from "../MockRMM.sol";
+import {SetUp} from "../SetUp.sol";
 
-contract CreditTest is Test {}
+contract CreditTest is SetUp {
+    function test_credit_TransfersTokens() public {
+        deal(address(weth), address(rmm), 1 ether);
+
+        uint256 preBalanceRMM = weth.balanceOf(address(rmm));
+        uint256 preBalanceAccount = weth.balanceOf(address(this));
+
+        rmm.credit(address(weth), address(this), 1 ether);
+
+        assertEq(weth.balanceOf(address(rmm)), preBalanceRMM - 1 ether);
+        assertEq(weth.balanceOf(address(this)), preBalanceAccount + 1 ether);
+    }
+}

--- a/test/unit/Debit.t.sol
+++ b/test/unit/Debit.t.sol
@@ -1,19 +1,12 @@
 /// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {Test} from "forge-std/Test.sol";
+import {SetUp} from "../SetUp.sol";
 import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
 import {FeeOnTransferToken} from "../../src/test/FeeOnTransferToken.sol";
-import {MockRMM} from "../MockRMM.sol";
 import {InsufficientPayment} from "./../../src/lib/RmmErrors.sol";
 
-contract DebitTest is Test {
-    MockRMM rmm;
-
-    function setUp() public {
-        rmm = new MockRMM(address(0), "", "");
-    }
-
+contract DebitTest is SetUp {
     function test_debit_TransfersTokens() public {
         MockERC20 token = new MockERC20("", "", 18);
 

--- a/test/unit/Init.t.sol
+++ b/test/unit/Init.t.sol
@@ -4,12 +4,8 @@ pragma solidity ^0.8.13;
 import {SetUp, RMM, InitParams, DEFAULT_EXPIRY} from "../SetUp.sol";
 import {Init} from "../../src/lib/RmmEvents.sol";
 import {AlreadyInitialized, InvalidStrike} from "../../src/lib/RmmErrors.sol";
-import {PYIndex, PYIndexLib, IPYieldToken} from "./../../src/RMM.sol";
 
 contract InitTest is SetUp {
-    using PYIndexLib for IPYieldToken;
-    using PYIndexLib for PYIndex;
-
     function test_init_MintsLiquidity()
         public
         withSY(address(this), 2000000 ether)
@@ -17,10 +13,9 @@ contract InitTest is SetUp {
     {
         InitParams memory initParams = getDefaultParams();
         setUpRMM(initParams);
-        PYIndex index = IPYieldToken(PT.YT()).newIndex();
 
         (uint256 totalLiquidity,) =
-            rmm.prepareInit(initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, index);
+            rmm.prepareInit(initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, newIndex());
 
         rmm.init(initParams.priceX, initParams.amountX, initParams.strike);
 
@@ -32,10 +27,9 @@ contract InitTest is SetUp {
     function test_init_AdjustsPool() public withSY(address(this), 2000000 ether) withPY(address(this), 1000000 ether) {
         InitParams memory initParams = getDefaultParams();
         setUpRMM(initParams);
-        PYIndex index = IPYieldToken(PT.YT()).newIndex();
 
         (, uint256 amountY) =
-            rmm.prepareInit(initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, index);
+            rmm.prepareInit(initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, newIndex());
         rmm.init(initParams.priceX, initParams.amountX, initParams.strike);
 
         assertEq(rmm.lastTimestamp(), block.timestamp, "lastTimestamp");
@@ -51,10 +45,9 @@ contract InitTest is SetUp {
     {
         InitParams memory initParams = getDefaultParams();
         setUpRMM(initParams);
-        PYIndex index = IPYieldToken(PT.YT()).newIndex();
 
         (, uint256 amountY) =
-            rmm.prepareInit(initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, index);
+            rmm.prepareInit(initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, newIndex());
 
         uint256 thisPreBalanceSY = SY.balanceOf(address(this));
         uint256 thisPreBalancePT = PT.balanceOf(address(this));
@@ -76,10 +69,9 @@ contract InitTest is SetUp {
     {
         InitParams memory initParams = getDefaultParams();
         setUpRMM(initParams);
-        PYIndex index = IPYieldToken(PT.YT()).newIndex();
 
         (uint256 totalLiquidity, uint256 amountY) =
-            rmm.prepareInit(initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, index);
+            rmm.prepareInit(initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, newIndex());
 
         vm.expectEmit();
 

--- a/test/unit/Init.t.sol
+++ b/test/unit/Init.t.sol
@@ -1,7 +1,7 @@
 /// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {SetUp, RMM, InitParams} from "../SetUp.sol";
+import {SetUp, RMM, InitParams, DEFAULT_EXPIRY} from "../SetUp.sol";
 import {Init} from "../../src/lib/RmmEvents.sol";
 import {AlreadyInitialized, InvalidStrike} from "../../src/lib/RmmErrors.sol";
 import {PYIndex, PYIndexLib, IPYieldToken} from "./../../src/RMM.sol";
@@ -10,75 +10,19 @@ contract InitTest is SetUp {
     using PYIndexLib for IPYieldToken;
     using PYIndexLib for PYIndex;
 
-    function test_init_StoresInitParams()
-        public
-        withSY(address(this), 2000000 ether)
-        withPY(address(this), 1000000 ether)
-    {
-        InitParams memory initParams = getDefaultParams();
-
-        rmm.init(
-            initParams.PT,
-            initParams.priceX,
-            initParams.amountX,
-            initParams.strike,
-            initParams.sigma,
-            initParams.fee,
-            initParams.curator
-        );
-
-        assertEq(rmm.strike(), initParams.strike);
-        assertEq(rmm.sigma(), initParams.sigma);
-        assertEq(rmm.fee(), initParams.fee);
-        assertEq(rmm.maturity(), initParams.maturity);
-        assertEq(rmm.curator(), initParams.curator);
-        assertEq(rmm.lastTimestamp(), block.timestamp);
-        assertEq(rmm.initTimestamp(), block.timestamp);
-    }
-
-    function test_init_StoresTokens()
-        public
-        withSY(address(this), 2000000 ether)
-        withPY(address(this), 1000000 ether)
-    {
-        InitParams memory initParams = getDefaultParams();
-
-        rmm.init(
-            initParams.PT,
-            initParams.priceX,
-            initParams.amountX,
-            initParams.strike,
-            initParams.sigma,
-            initParams.fee,
-            initParams.curator
-        );
-
-        assertEq(address(rmm.PT()), address(PT));
-        assertEq(address(rmm.YT()), address(YT));
-        assertEq(address(rmm.SY()), address(SY));
-    }
-
     function test_init_MintsLiquidity()
         public
         withSY(address(this), 2000000 ether)
         withPY(address(this), 1000000 ether)
     {
         InitParams memory initParams = getDefaultParams();
+        setUpRMM(initParams);
         PYIndex index = IPYieldToken(PT.YT()).newIndex();
 
-        (uint256 totalLiquidity,) = rmm.prepareInit(
-            initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, initParams.maturity, index
-        );
+        (uint256 totalLiquidity,) =
+            rmm.prepareInit(initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, index);
 
-        rmm.init(
-            initParams.PT,
-            initParams.priceX,
-            initParams.amountX,
-            initParams.strike,
-            initParams.sigma,
-            initParams.fee,
-            initParams.curator
-        );
+        rmm.init(initParams.priceX, initParams.amountX, initParams.strike);
 
         assertEq(rmm.totalLiquidity(), totalLiquidity);
         assertEq(rmm.balanceOf(address(this)), totalLiquidity - rmm.BURNT_LIQUIDITY());
@@ -87,25 +31,17 @@ contract InitTest is SetUp {
 
     function test_init_AdjustsPool() public withSY(address(this), 2000000 ether) withPY(address(this), 1000000 ether) {
         InitParams memory initParams = getDefaultParams();
+        setUpRMM(initParams);
         PYIndex index = IPYieldToken(PT.YT()).newIndex();
 
-        (, uint256 amountY) = rmm.prepareInit(
-            initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, initParams.maturity, index
-        );
-
-        rmm.init(
-            initParams.PT,
-            initParams.priceX,
-            initParams.amountX,
-            initParams.strike,
-            initParams.sigma,
-            initParams.fee,
-            initParams.curator
-        );
+        (, uint256 amountY) =
+            rmm.prepareInit(initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, index);
+        rmm.init(initParams.priceX, initParams.amountX, initParams.strike);
 
         assertEq(rmm.lastTimestamp(), block.timestamp, "lastTimestamp");
         assertEq(rmm.reserveX(), initParams.amountX, "reserveX");
         assertEq(rmm.reserveY(), amountY, "reserveY");
+        assertEq(rmm.strike(), initParams.strike);
     }
 
     function test_init_TransfersTokens()
@@ -114,26 +50,18 @@ contract InitTest is SetUp {
         withPY(address(this), 1000000 ether)
     {
         InitParams memory initParams = getDefaultParams();
+        setUpRMM(initParams);
         PYIndex index = IPYieldToken(PT.YT()).newIndex();
 
-        (, uint256 amountY) = rmm.prepareInit(
-            initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, initParams.maturity, index
-        );
+        (, uint256 amountY) =
+            rmm.prepareInit(initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, index);
 
         uint256 thisPreBalanceSY = SY.balanceOf(address(this));
         uint256 thisPreBalancePT = PT.balanceOf(address(this));
         uint256 rmmPreBalanceSY = SY.balanceOf(address(rmm));
         uint256 rmmPreBalancePT = PT.balanceOf(address(rmm));
 
-        rmm.init(
-            initParams.PT,
-            initParams.priceX,
-            initParams.amountX,
-            initParams.strike,
-            initParams.sigma,
-            initParams.fee,
-            initParams.curator
-        );
+        rmm.init(initParams.priceX, initParams.amountX, initParams.strike);
 
         assertEq(SY.balanceOf(address(this)), thisPreBalanceSY - initParams.amountX);
         assertEq(PT.balanceOf(address(this)), thisPreBalancePT - amountY);
@@ -147,11 +75,11 @@ contract InitTest is SetUp {
         withPY(address(this), 1000000 ether)
     {
         InitParams memory initParams = getDefaultParams();
+        setUpRMM(initParams);
         PYIndex index = IPYieldToken(PT.YT()).newIndex();
 
-        (uint256 totalLiquidity, uint256 amountY) = rmm.prepareInit(
-            initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, initParams.maturity, index
-        );
+        (uint256 totalLiquidity, uint256 amountY) =
+            rmm.prepareInit(initParams.priceX, initParams.amountX, initParams.strike, initParams.sigma, index);
 
         vm.expectEmit();
 
@@ -165,19 +93,10 @@ contract InitTest is SetUp {
             initParams.strike,
             initParams.sigma,
             initParams.fee,
-            initParams.maturity,
-            initParams.curator
+            DEFAULT_EXPIRY
         );
 
-        rmm.init(
-            initParams.PT,
-            initParams.priceX,
-            initParams.amountX,
-            initParams.strike,
-            initParams.sigma,
-            initParams.fee,
-            initParams.curator
-        );
+        rmm.init(initParams.priceX, initParams.amountX, initParams.strike);
     }
 
     function test_init_RevertsIfAlreadyInitialized()
@@ -189,16 +108,7 @@ contract InitTest is SetUp {
         InitParams memory initParams = getDefaultParams();
 
         vm.expectRevert(AlreadyInitialized.selector);
-
-        rmm.init(
-            initParams.PT,
-            initParams.priceX,
-            initParams.amountX,
-            initParams.strike,
-            initParams.sigma,
-            initParams.fee,
-            initParams.curator
-        );
+        rmm.init(initParams.priceX, initParams.amountX, initParams.strike);
     }
 
     function test_init_RevertsIfInvalidStrike()
@@ -207,18 +117,10 @@ contract InitTest is SetUp {
         withPY(address(this), 1000000 ether)
     {
         InitParams memory initParams = getDefaultParams();
+        setUpRMM(initParams);
 
-        vm.expectRevert(abi.encodeWithSelector(InvalidStrike.selector));
-
-        rmm.init(
-            initParams.PT,
-            initParams.priceX,
-            initParams.amountX,
-            1 ether,
-            initParams.sigma,
-            initParams.fee,
-            initParams.curator
-        );
+        vm.expectRevert(InvalidStrike.selector);
+        rmm.init(initParams.priceX, initParams.amountX, 1 ether);
     }
 
     function test_init_RevertsWhenLocked()


### PR DESCRIPTION
Despite its name this branch doesn't actually remove the `init` function, in fact it moves some parameters from `init` to the `constructor` function, allowing them to become `immutable`, yay!